### PR TITLE
fix: remove unnecessary protocol prepend in GA

### DIFF
--- a/web/workspace/partials/footer.dust
+++ b/web/workspace/partials/footer.dust
@@ -134,7 +134,7 @@
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','{global.protocol}://www.google-analytics.com/analytics.js','ga');
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 ga('create', 'UA-42395806-1', 'auto');
 ga('send', 'pageview');
 </script>


### PR DESCRIPTION
Protocol here in addition to `//` which defaults to the current protocol anyway causes the url path to form as the entire current domain plus the domain in script. Result: `https://dadi.tech/://www.google-analytics.com/analytics.js`