### PR TITLE
fix: add github release feed datasources

### DIFF
--- a/web/workspace/pages/latest.json
+++ b/web/workspace/pages/latest.json
@@ -5,7 +5,10 @@
   },
   "datasources": [
     "latest",
-    "latest-footer"
+    "latest-footer",
+    "github-api",
+    "github-cdn",
+    "github-web"
   ],
   "routes": [
     {


### PR DESCRIPTION
a [ticket](https://github.com/dadi/web/issues/159) has been raised against Web for the RSS feed not working, but I think this is the solution - the datasources are not included in `latest.json`

https://github.com/dadi/dadi.tech/blob/master/web/workspace/pages/latest.json#L6-L9
