### PR TITLE
Add redirect for product URLs

### DIFF
--- a/web/workspace/pages/product.json
+++ b/web/workspace/pages/product.json
@@ -18,6 +18,10 @@
     {
       "path": "/:lang/:product",
       "fetch": "products"
+    },
+    {
+      "path": "/:product(api|publish|cdn|web|track|visualize|identity|match|predict|queue|store)",
+      "fetch": "products"
     }
   ]
 } 


### PR DESCRIPTION
This PR adds redirects for `/:product` to `/:lang/:product`. For example, https://dadi.tech/cdn redirects to https://dadi.tech/en/cdn if the language is English.